### PR TITLE
Correction keyword name and external forces visualization

### DIFF
--- a/src/DataIn.f90
+++ b/src/DataIn.f90
@@ -740,6 +740,7 @@ contains
           particle_list(inode)%FXp(1) = GetReal()
           particle_list(inode)%FXp(2) = GetReal()
           particle_list(inode)%FXp(3) = GetReal()
+          
        case(3)    ! by body
           ibody = GetInt()    ! body number
           fxp = GetReal()

--- a/src/DataIn.f90
+++ b/src/DataIn.f90
@@ -719,27 +719,29 @@ contains
     use FFI
     implicit none
 
-    integer k, inode, i, ibody
+    integer k, ipart, i, ibody
     real(8):: fxp, fyp, fzp
-    integer,parameter:: nbkw = 4
+    integer,parameter:: nbkw = 5
     character(4),parameter:: kw(nbkw) = &
-                             (/'endl','node','body','grav' /)
+                             (/'endl','part','body','grav','node' /)
 
     if(nb_body.eq.0) then
        stop '*** Error *** nbby must be defined !'
     end if
 
     do while(.true.)
+       
        k = keyword(kw,nbkw)
        select case(k)
+       
        case(1)    ! end load
           exit
 
-       case(2)    ! by node 
-          inode = GetInt()
-          particle_list(inode)%FXp(1) = GetReal()
-          particle_list(inode)%FXp(2) = GetReal()
-          particle_list(inode)%FXp(3) = GetReal()
+       case(2)    ! by particle 
+          ipart = GetInt()
+          particle_list(ipart)%FXp(1) = GetReal()
+          particle_list(ipart)%FXp(2) = GetReal()
+          particle_list(ipart)%FXp(3) = GetReal()
           
        case(3)    ! by body
           ibody = GetInt()    ! body number
@@ -760,6 +762,9 @@ contains
           body_list(ibody)%Gravp(2) = GetReal()
           body_list(ibody)%Gravp(3) = GetReal()
 
+       case (5) ! Legacy keyword
+         write(*,*) '*** Error *** : Please use the keyword part instead of node to apply a load to a particle'
+       
        case default    ! error
           call ErrorMsg()
           stop 'error GetLoad'

--- a/src/DataOut.f90
+++ b/src/DataOut.f90
@@ -373,6 +373,30 @@ contains
     end do !p
     write(iow11,32) indent//indent//indent, 'DataArray' ! close 'disz'
 
+    ! fxpx
+    write(iow11,33) indent//indent//indent, 'DataArray', 'Float32', 'fxpx'
+    do p = 1, nb_particle
+        pt => particle_list(p)
+        write(iow11, "(A,e12.4)") indent//indent//indent//indent, pt%FXp(1)
+    end do !p
+    write(iow11,32) indent//indent//indent, 'DataArray' ! close 'fxpx'
+
+    ! fxpy
+    write(iow11,33) indent//indent//indent, 'DataArray', 'Float32', 'fxpy'
+    do p = 1, nb_particle
+        pt => particle_list(p)
+        write(iow11, "(A,e12.4)") indent//indent//indent//indent, pt%FXp(2)
+    end do !p
+    write(iow11,32) indent//indent//indent, 'DataArray' ! close 'fxpy'
+
+    ! fxpz
+    write(iow11,33) indent//indent//indent, 'DataArray', 'Float32', 'fxpz'
+    do p = 1, nb_particle
+        pt => particle_list(p)
+        write(iow11, "(A,e12.4)") indent//indent//indent//indent, pt%FXp(3)
+    end do !p
+    write(iow11,32) indent//indent//indent, 'DataArray' ! close 'fxpz'
+
     ! vol
     write(iow11,33) indent//indent//indent, 'DataArray', 'Float32', 'vol'
     do p = 1, nb_particle


### PR DESCRIPTION
### Content
This pull request includes:

1. Correction in the keyword used to apply an external force to a particle.
2. Applied external forces visualization.

### Verification

The code:
```
! particle load test
load
part 32016 0.0 0.0 -100.0
endl
```
Produces:

![image](https://user-images.githubusercontent.com/22794916/185923274-14f7600c-f2a7-496e-a0df-409c09f72b30.png)

Note that the particle id in Paraview begin in 0 but in the MPM code begin in 1.

### Old keyword
If the old keyword is used, an error message is printing, suggesting the use of the corrected one. 

The code:

```
! particle load test
load
node 32016 0.0 0.0 -100.0
endl
```
Produces:

```
 *** Error *** : Please use the keyword part instead of node to apply a load to a particle
```